### PR TITLE
iMX8M/print_fit_hab.sh: fix determining the file size

### DIFF
--- a/iMX8M/print_fit_hab.sh
+++ b/iMX8M/print_fit_hab.sh
@@ -6,18 +6,18 @@ let fit_off=$1
 
 # We dd flash.bin to 33KB "0x8400" offset, so need minus 0x8400
 let uboot_sign_off=$((fit_off - 0x8400 + 0x3000))
-let uboot_size=$(ls -lct u-boot-nodtb.bin | awk '{print $5}')
+let uboot_size=$(stat --printf="%s" u-boot-nodtb.bin)
 let uboot_load_addr=0x40200000
 
 let atf_sign_off=$((uboot_sign_off + uboot_size))
 let atf_load_addr=0x910000
-let atf_size=$(ls -lct bl31.bin | awk '{print $5}')
+let atf_size=$(stat --printf="%s" bl31.bin)
 
 if [ ! -f $BL32 ]; then
 	let tee_size=0x0
 	let tee_sign_off=$((atf_sign_off + atf_size))
 else
-	let tee_size=$(ls -lct tee.bin | awk '{print $5}')
+	let tee_size=$(stat --printf="%s" tee.bin)
 
 	let tee_sign_off=$((atf_sign_off + atf_size))
 	let tee_load_addr=0xfe000000
@@ -52,7 +52,7 @@ for dtname in $*
 do
 	if [ ${cnt} != 0 ]
 	then
-		let fdt${cnt}_size=$(ls -lct $dtname | awk '{print $5}')
+		let fdt${cnt}_size=$(stat --printf="%s" $dtname)
 
 		let fdt${cnt}_sign_off=$((last_sign_off))
 		let fdt${cnt}_load_addr=$((last_load_addr))


### PR DESCRIPTION
The command 'ls -lct', used for determining the file size,
does not behave consistently, causing the file size to be 0
sometimes. This breaks the image signing in case of the secure boot.

Signed-off-by: Aleksandar Nikolic <aleksandar.nikolic@mixed-mode.de>